### PR TITLE
Add Query::Type to ConceptRowStream

### DIFF
--- a/proto/query.proto
+++ b/proto/query.proto
@@ -12,6 +12,12 @@ package typedb.protocol;
 
 message Query {
 
+    enum Type {
+        READ = 0;
+        WRITE = 1;
+        SCHEMA = 2;
+    }
+
     message Req {
         Options options = 1;
         string query = 2;
@@ -40,6 +46,7 @@ message Query {
 
             message ConceptRowStream {
                 repeated string column_variable_names = 1;
+                Type query_type = 2;
             }
         }
     }

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -42,6 +42,7 @@ message Query {
 
             message ReadableConceptTreeStream {
                 // note: we could use this first response to record debug info, type annotations, warnings, etc
+                // TODO: Add Type query_type
             }
 
             message ConceptRowStream {


### PR DESCRIPTION
## Release notes: usage and product changes
In 3.0, we no longer use parsers on our user-facing clients, and we no longer can differentiate the types of queries we are executing on the server. However, it can be sometimes useful (e.g. for extra logging/messaging) to have at least some information about the nature of the queries. 
For these purposes, we add the executed query's type to `ConceptRowStream`. 

## Implementation
For now, it's just general `Read/Write/Schema` (like transaction types), which is enough for our existing tasks. 