### PR TITLE
Add sign-in request for authentication token retrieval

### DIFF
--- a/grpc/java/BUILD
+++ b/grpc/java/BUILD
@@ -16,6 +16,7 @@ java_grpc_library(
         "//proto:answer-proto",
         "//proto:concept-proto",
         "//proto:connection-proto",
+        "//proto:authentication-proto",
         "//proto:logic-proto",
         "//proto:options-proto",
         "//proto:query-proto",

--- a/grpc/nodejs/BUILD
+++ b/grpc/nodejs/BUILD
@@ -32,6 +32,7 @@ ts_grpc_compile(
         "//proto:answer-proto",
         "//proto:concept-proto",
         "//proto:connection-proto",
+        "//proto:authentication-proto",
         "//proto:logic-proto",
         "//proto:options-proto",
         "//proto:query-proto",

--- a/grpc/rust/BUILD
+++ b/grpc/rust/BUILD
@@ -19,6 +19,7 @@ rust_tonic_compile(
         "//proto:answer-proto",
         "//proto:concept-proto",
         "//proto:connection-proto",
+        "//proto:authentication-proto",
         "//proto:logic-proto",
         "//proto:options-proto",
         "//proto:query-proto",

--- a/grpc/rust/build.rs
+++ b/grpc/rust/build.rs
@@ -5,6 +5,7 @@
 fn main() -> std::io::Result<()> {
     let protos = vec![
         "../../proto/answer.proto",
+        "../../proto/authentication.proto",
         "../../proto/concept.proto",
         "../../proto/connection.proto",
         "../../proto/database.proto",

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -54,8 +54,9 @@ proto_library(
     name = "connection-proto",
     srcs = ["connection.proto"],
     deps = [
-        ":version-proto",
-        ":database-proto"
+        ":authentication-proto",
+        ":database-proto",
+        ":version-proto"
     ],
 )
 

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -11,6 +11,7 @@ proto_library(
     srcs = [":typedb-service.proto"],
     deps = [
         ":connection-proto",
+        ":authentication-proto",
         ":server-proto",
         ":user-proto",
         ":database-proto",
@@ -37,6 +38,11 @@ proto_library(
     name = "answer-proto",
     srcs = ["answer.proto"],
     deps = [":concept-proto"],
+)
+
+proto_library(
+    name = "authentication-proto",
+    srcs = ["authentication.proto"],
 )
 
 proto_library(

--- a/proto/authentication.proto
+++ b/proto/authentication.proto
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+syntax = "proto3";
+
+package typedb.protocol;
+
+message Authentication {
+
+  // TODO: How to extend it if other credentials appear? Make SignInPassword + SignInXXX, or make username + password optional?
+  message SignIn {
+    message Req {
+      string username = 1;
+      string password = 2;
+    }
+
+    message Res {
+      string token = 1;
+    }
+  }
+}

--- a/proto/authentication.proto
+++ b/proto/authentication.proto
@@ -8,11 +8,14 @@ package typedb.protocol;
 
 message Authentication {
 
-  // TODO: How to extend it if other credentials appear? Make SignInPassword + SignInXXX, or make username + password optional?
   message SignIn {
     message Req {
-      string username = 1;
-      string password = 2;
+      message Password {
+        string username = 1;
+        string password = 2;
+      }
+
+      optional Password password = 1;
     }
 
     message Res {

--- a/proto/authentication.proto
+++ b/proto/authentication.proto
@@ -15,7 +15,10 @@ message Authentication {
         string password = 2;
       }
 
-      optional Password password = 1;
+      oneof credentials {
+        Password password = 1;
+        // extend by other credential kinds
+      }
     }
 
     message Res {

--- a/proto/authentication.proto
+++ b/proto/authentication.proto
@@ -7,22 +7,23 @@ syntax = "proto3";
 package typedb.protocol;
 
 message Authentication {
+  message Token {
+    message Create {
+      message Req {
+        message Password {
+          string username = 1;
+          string password = 2;
+        }
 
-  message SignIn {
-    message Req {
-      message Password {
-        string username = 1;
-        string password = 2;
+        oneof credentials {
+          Password password = 1;
+          // extend by other credential kinds
+        }
       }
 
-      oneof credentials {
-        Password password = 1;
-        // extend by other credential kinds
+      message Res {
+        string token = 1;
       }
-    }
-
-    message Res {
-      string token = 1;
     }
   }
 }

--- a/proto/connection.proto
+++ b/proto/connection.proto
@@ -4,8 +4,9 @@
 
 syntax = "proto3";
 
-import "proto/version.proto";
+import "proto/authentication.proto";
 import "proto/database.proto";
+import "proto/version.proto";
 
 package typedb.protocol;
 
@@ -16,6 +17,8 @@ message Connection {
       Version version = 1;
       string driver_lang = 2;
       string driver_version = 3;
+
+      Authentication.SignIn.Req authentication = 4;
     }
 
     message Res {
@@ -24,6 +27,8 @@ message Connection {
 
       // pre-send all databases and replica info
       DatabaseManager.All.Res databases_all = 3;
+
+      Authentication.SignIn.Res authentication = 4;
     }
   }
 }

--- a/proto/connection.proto
+++ b/proto/connection.proto
@@ -18,7 +18,7 @@ message Connection {
       string driver_lang = 2;
       string driver_version = 3;
 
-      Authentication.SignIn.Req authentication = 4;
+      Authentication.Token.Create.Req authentication = 4;
     }
 
     message Res {
@@ -28,7 +28,7 @@ message Connection {
       // pre-send all databases and replica info
       DatabaseManager.All.Res databases_all = 3;
 
-      Authentication.SignIn.Res authentication = 4;
+      Authentication.Token.Create.Res authentication = 4;
     }
   }
 }

--- a/proto/connection.proto
+++ b/proto/connection.proto
@@ -22,8 +22,6 @@ message Connection {
       uint64 server_duration_millis = 1;
       ConnectionID connection_id = 2;
 
-      // TODO: initial Token
-
       // pre-send all databases and replica info
       DatabaseManager.All.Res databases_all = 3;
     }

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -6,7 +6,6 @@ syntax = "proto3";
 
 import "proto/answer.proto";
 import "proto/options.proto";
-import "proto/concept.proto";
 
 package typedb.protocol;
 

--- a/proto/typedb-service.proto
+++ b/proto/typedb-service.proto
@@ -19,7 +19,7 @@ service TypeDB {
     rpc connection_open (Connection.Open.Req) returns (Connection.Open.Res);
 
     // Authentication API
-    rpc sign_in (Authentication.Token.Create.Req) returns (Authentication.Token.Create.Res);
+    rpc authentication_token_create (Authentication.Token.Create.Req) returns (Authentication.Token.Create.Res);
 
     // Server Manager API
     rpc servers_all (ServerManager.All.Req) returns (ServerManager.All.Res);

--- a/proto/typedb-service.proto
+++ b/proto/typedb-service.proto
@@ -4,6 +4,7 @@
 
 syntax = "proto3";
 
+import "proto/authentication.proto";
 import "proto/connection.proto";
 import "proto/database.proto";
 import "proto/server.proto";
@@ -16,6 +17,9 @@ service TypeDB {
 
     // Connection API
     rpc connection_open (Connection.Open.Req) returns (Connection.Open.Res);
+
+    // Authentication API
+    rpc sign_in (Authentication.SignIn.Req) returns (Authentication.SignIn.Res);
 
     // Server Manager API
     rpc servers_all (ServerManager.All.Req) returns (ServerManager.All.Res);

--- a/proto/typedb-service.proto
+++ b/proto/typedb-service.proto
@@ -19,7 +19,7 @@ service TypeDB {
     rpc connection_open (Connection.Open.Req) returns (Connection.Open.Res);
 
     // Authentication API
-    rpc sign_in (Authentication.SignIn.Req) returns (Authentication.SignIn.Res);
+    rpc sign_in (Authentication.Token.Create.Req) returns (Authentication.Token.Create.Res);
 
     // Server Manager API
     rpc servers_all (ServerManager.All.Req) returns (ServerManager.All.Res);

--- a/proto/version.proto
+++ b/proto/version.proto
@@ -7,7 +7,7 @@ syntax = "proto3";
 package typedb.protocol;
 
 enum Version {
-  reserved 1, 2, 3; // add past version numbers into the reserved range
+  reserved 1, 2, 3, 4; // add past version numbers into the reserved range
   UNSPECIFIED = 0;
-  VERSION = 4;
+  VERSION = 5;
 }


### PR DESCRIPTION
## Release notes: usage and product changes
A new mechanism of authentication tokens has been introduced to replace the old way of sending usernames and passwords through the network with every request.

Instead, all user credentials (currently, it's usernames and passwords) are sent only:
* as a part of `connection_open` request for authentication and authorization, with a temporary token returned;
* as a part of `sign_in` request for sign ins within an established connection (to change the user or to get a new authentication token).
Then, all further requests are expected to be authenticated only by temporary, less sensitive tokens. 

The approach is extensible to other credential types that can be introduced in the future.

## Implementation
