### PR TITLE
Fix build errors and update dependencies

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -17,25 +17,25 @@ build:
       command: |
         bazel run @typedb_dependencies//factory/analysis:dependency-analysis
   correctness:
-#    build:
-#      image: typedb-ubuntu-22.04
-#      command: |
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel build //...
-#        bazel run @typedb_dependencies//tool/checkstyle:test-coverage
-#        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
-#    build-dependency:
-#      image: typedb-ubuntu-22.04
-#      command: |
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        dependencies/maven/update.sh
-#        git diff --exit-code dependencies/maven/artifacts.snapshot
-#        bazel run @typedb_dependencies//tool/unuseddeps:unused-deps -- list
+    build:
+      image: typedb-ubuntu-22.04
+      command: |
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel build //...
+        bazel run @typedb_dependencies//tool/checkstyle:test-coverage
+        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+    build-dependency:
+      image: typedb-ubuntu-22.04
+      command: |
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        dependencies/maven/update.sh
+        git diff --exit-code dependencies/maven/artifacts.snapshot
+        bazel run @typedb_dependencies//tool/unuseddeps:unused-deps -- list
     deploy-crate-snapshot:
       filter:
         owner: typedb
-        branch: [master, development, "3.0"]
-#      dependencies: [build, build-dependency]
+        branch: [master]
+      dependencies: [build, build-dependency]
       image: typedb-ubuntu-22.04
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
@@ -68,7 +68,7 @@ build:
 release:
   filter:
     owner: typedb
-    branch: [ master, "3.0" ]
+    branch: [master]
   validation:
     validate-release-notes:
       image: typedb-ubuntu-22.04

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -5,8 +5,9 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def typedb_dependencies():
+    # TODO: Return typedb
     git_repository(
         name = "typedb_dependencies",
-        remote = "https://github.com/typedb/typedb-dependencies",
-        commit = "ab777bf067b1930e35146fd8e25a76a4a360aa74", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        remote = "https://github.com/farost/typedb-dependencies",
+        commit = "24a0d12e3523c96a349e0742435194423f2dd1f9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -5,9 +5,8 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def typedb_dependencies():
-    # TODO: Return typedb
     git_repository(
         name = "typedb_dependencies",
-        remote = "https://github.com/farost/typedb-dependencies",
-        commit = "24a0d12e3523c96a349e0742435194423f2dd1f9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        remote = "https://github.com/typedb/typedb-dependencies",
+        commit = "fac1121c903b0c9e5924d391a883e4a0749a82a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -16,6 +16,7 @@ proto_library(
         ":user-proto",
         ":database-proto",
         ":transaction-proto",
+        ":migration-proto",
     ],
 )
 


### PR DESCRIPTION
## Release notes: usage and product changes
Support build on Apple Clang 17+ by updating dependencies (details: https://github.com/typedb/typedb-dependencies/pull/577). 
Fix bazel build by adding an implicit dependency to the build configuration.
Reintroduce CI correctness validation jobs.

## Implementation
