### PR TITLE
Add cluster support

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -66,6 +66,7 @@ proto_library(
     deps = [
         ":authentication-proto",
         ":database-proto",
+        ":server-proto",
         ":version-proto"
     ],
 )

--- a/proto/connection.proto
+++ b/proto/connection.proto
@@ -23,7 +23,7 @@ message Connection {
     message Res {
       uint64 server_duration_millis = 1;
       ConnectionID connection_id = 2;
-      ServerManager.All.Res servers_all = 3;
+      ServerManager.All.Res servers_all = 3; // TODO: It might not be used / needed in the end! Discuss.
       Authentication.Token.Create.Res authentication = 4;
     }
   }

--- a/proto/connection.proto
+++ b/proto/connection.proto
@@ -12,7 +12,6 @@ import "proto/version.proto";
 package typedb.protocol;
 
 message Connection {
-
   message Open {
     message Req {
       Version version = 1;
@@ -24,9 +23,8 @@ message Connection {
     message Res {
       uint64 server_duration_millis = 1;
       ConnectionID connection_id = 2;
-      DatabaseManager.All.Res databases_all = 3;
+      ServerManager.All.Res servers_all = 3;
       Authentication.Token.Create.Res authentication = 4;
-      ServerManager.All.Res servers_all = 5;
     }
   }
 }

--- a/proto/connection.proto
+++ b/proto/connection.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 
 import "proto/authentication.proto";
 import "proto/database.proto";
+import "proto/server.proto";
 import "proto/version.proto";
 
 package typedb.protocol;
@@ -17,23 +18,20 @@ message Connection {
       Version version = 1;
       string driver_lang = 2;
       string driver_version = 3;
-
       Authentication.Token.Create.Req authentication = 4;
     }
 
     message Res {
       uint64 server_duration_millis = 1;
       ConnectionID connection_id = 2;
-
-      // pre-send all databases and replica info
       DatabaseManager.All.Res databases_all = 3;
-
       Authentication.Token.Create.Res authentication = 4;
+      ServerManager.Version.Res server_version = 5;
+      ServerManager.All.Res servers_all = 6;
     }
   }
 }
 
-// Connection ID and Token are expected in all message metadata
 message ConnectionID {
   bytes id = 1;
 }

--- a/proto/connection.proto
+++ b/proto/connection.proto
@@ -23,7 +23,7 @@ message Connection {
     message Res {
       uint64 server_duration_millis = 1;
       ConnectionID connection_id = 2;
-      ServerManager.All.Res servers_all = 3; // TODO: It might not be used / needed in the end! Discuss.
+      ServerManager.All.Res servers_all = 3;
       Authentication.Token.Create.Res authentication = 4;
     }
   }

--- a/proto/connection.proto
+++ b/proto/connection.proto
@@ -26,8 +26,7 @@ message Connection {
       ConnectionID connection_id = 2;
       DatabaseManager.All.Res databases_all = 3;
       Authentication.Token.Create.Res authentication = 4;
-      Server.Version.Res server_version = 5;
-      ServerManager.All.Res servers_all = 6;
+      ServerManager.All.Res servers_all = 5;
     }
   }
 }

--- a/proto/connection.proto
+++ b/proto/connection.proto
@@ -26,7 +26,7 @@ message Connection {
       ConnectionID connection_id = 2;
       DatabaseManager.All.Res databases_all = 3;
       Authentication.Token.Create.Res authentication = 4;
-      ServerManager.Version.Res server_version = 5;
+      Server.Version.Res server_version = 5;
       ServerManager.All.Res servers_all = 6;
     }
   }

--- a/proto/database.proto
+++ b/proto/database.proto
@@ -16,14 +16,14 @@ message DatabaseManager {
         }
 
         message Res {
-            DatabaseReplicas database = 1;
+            Database database = 1;
         }
     }
 
     message All {
         message Req {}
         message Res {
-            repeated DatabaseReplicas databases = 1;
+            repeated Database databases = 1;
         }
     }
 
@@ -43,7 +43,7 @@ message DatabaseManager {
         }
 
         message Res {
-            DatabaseReplicas database = 1;
+            Database database = 1;
         }
     }
 
@@ -58,20 +58,8 @@ message DatabaseManager {
     }
 }
 
-message DatabaseReplicas {
-
-    string name = 1;
-    repeated Replica replicas = 2;
-
-    message Replica {
-        string address = 1;
-        bool primary = 2;
-        bool preferred = 3;
-        int64 term = 4;
-    }
-}
-
 message Database {
+    string name = 1;
 
     message Schema {
         message Req {

--- a/proto/error.proto
+++ b/proto/error.proto
@@ -7,7 +7,7 @@ syntax = "proto3";
 package typedb.protocol;
 
 // This is an emulation of the google ErrorDetails message. Generally, ErrorDetails are submitted via the GRPC error
-// mechanism, but a manual error sending is required in streams
+// mechanism, but a manual error sending is useful to differentiate error levels in streams
 message Error {
     string error_code = 1;
     string domain = 2;

--- a/proto/server.proto
+++ b/proto/server.proto
@@ -25,6 +25,8 @@ message Server {
         Secondary = 1;
     }
 
+    // Address is encapsulated so it is a type-safe protobuf message which can be encoded in connection-related error
+    // messages.
     message Address {
         string address = 1;
     }

--- a/proto/server.proto
+++ b/proto/server.proto
@@ -17,18 +17,21 @@ message ServerManager {
 
 message Server {
     Address address = 1;
-    ReplicaType replica_type = 2;
-    int64 term = 3;
+    optional ReplicationStatus replication_status = 2;
 
-    enum ReplicaType {
-        Primary = 0;
-        Secondary = 1;
-    }
-
-    // Address is encapsulated so it is a type-safe protobuf message which can be encoded in connection-related error
-    // messages.
+    // Address is encapsulated so it is a type-safe message which can be encoded in connection-related errors.
     message Address {
         string address = 1;
+    }
+
+    message ReplicationStatus {
+        ReplicaType replica_type = 1;
+        int64 term = 2;
+
+        enum ReplicaType {
+            Primary = 0;
+            Secondary = 1;
+        }
     }
 
     message Version {

--- a/proto/server.proto
+++ b/proto/server.proto
@@ -7,15 +7,33 @@ syntax = "proto3";
 package typedb.protocol;
 
 message ServerManager {
-
     message All {
         message Req {}
         message Res {
             repeated Server servers = 1;
         }
     }
+
+    message Version {
+        message Req {}
+        message Res {
+            string distribution = 1;
+            string version = 2;
+        }
+    }
 }
 
 message Server {
-    string address = 1;
+    Address address = 1;
+    ReplicaType replica_type = 2;
+    int64 term = 3;
+
+    enum ReplicaType {
+        Primary = 0;
+        Secondary = 1;
+    }
+
+    message Address {
+        string address = 1;
+    }
 }

--- a/proto/server.proto
+++ b/proto/server.proto
@@ -16,13 +16,8 @@ message ServerManager {
 }
 
 message Server {
-    Address address = 1;
+    string address = 1;
     optional ReplicationStatus replication_status = 2;
-
-    // Address is encapsulated so it is a type-safe message which can be encoded in connection-related errors.
-    message Address {
-        string address = 1;
-    }
 
     message ReplicationStatus {
         ReplicaType replica_type = 1;

--- a/proto/server.proto
+++ b/proto/server.proto
@@ -17,9 +17,9 @@ message ServerManager {
 
 message Server {
     string address = 1;
-    optional ReplicationStatus replication_status = 2;
+    optional ReplicaStatus replica_status = 2;
 
-    message ReplicationStatus {
+    message ReplicaStatus {
         ReplicaType replica_type = 1;
         int64 term = 2;
 

--- a/proto/server.proto
+++ b/proto/server.proto
@@ -13,14 +13,6 @@ message ServerManager {
             repeated Server servers = 1;
         }
     }
-
-    message Version {
-        message Req {}
-        message Res {
-            string distribution = 1;
-            string version = 2;
-        }
-    }
 }
 
 message Server {
@@ -35,5 +27,13 @@ message Server {
 
     message Address {
         string address = 1;
+    }
+
+    message Version {
+        message Req {}
+        message Res {
+            string distribution = 1;
+            string version = 2;
+        }
     }
 }

--- a/proto/typedb-service.proto
+++ b/proto/typedb-service.proto
@@ -25,6 +25,9 @@ service TypeDB {
     // Server Manager API
     rpc servers_all (ServerManager.All.Req) returns (ServerManager.All.Res);
 
+    // Server API
+    rpc server_version (Server.Version.Req) returns (Server.Version.Res);
+
     // User Manager API
     rpc users_get (UserManager.Get.Req) returns (UserManager.Get.Res);
     rpc users_all (UserManager.All.Req) returns (UserManager.All.Res);


### PR DESCRIPTION
## Release notes: usage and product changes
Introduce cluster support for TypeDB 3.x, featuring server replicas and the new version message.

## Implementation
Remove database replicas. Instead, add server replicas (by extending the usual `Server` message) with a similar set of fields.

Instead of adding a `is_primary` flag, introduce an extensible enum `ReplicaType` for more granular split between primary and supporting nodes.  

To reduce the network overhead, this new information is provided in the initial server's connection response.