### PR TITLE
Add server_status message to the raft peering service

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -31,6 +31,9 @@ proto_library(
 proto_library(
     name = "raft-peering-proto",
     srcs = [":raft-peering.proto"],
+    deps = [
+        ":server-proto",
+    ],
 )
 
 proto_library(

--- a/proto/raft-peering-service.proto
+++ b/proto/raft-peering-service.proto
@@ -5,5 +5,6 @@ import "proto/raft-peering.proto";
 package typedb.protocol;
 
 service RaftPeering {
-  rpc Peering(PeeringRequest) returns (PeeringResponse);
+  rpc peering (Peering.Req) returns (Peering.Res);
+  rpc server_status (ServerStatus.Req) returns (ServerStatus.Res);
 }

--- a/proto/raft-peering-service.proto
+++ b/proto/raft-peering-service.proto
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 syntax = "proto3";
 
 import "proto/raft-peering.proto";

--- a/proto/raft-peering.proto
+++ b/proto/raft-peering.proto
@@ -8,6 +8,7 @@ package typedb.protocol;
 
 import "proto/server.proto";
 
+// TODO: Rename to Replication
 message Peering {
     message Req {
         uint64 from_id = 1;
@@ -22,9 +23,6 @@ message ServerStatus {
     message Req {}
 
     message Res {
-        // TODO: Currently, it's identical to Server. But it won't necessarily be the case forever, so these fields are
-        // split. Additionally, we want to highlight that the address is the connection address.
-        // TODO: We may move ReplicaStatus somewhere else now...
         string connection_address = 1;
         Server.ReplicaStatus replica_status = 2;
     }

--- a/proto/raft-peering.proto
+++ b/proto/raft-peering.proto
@@ -2,11 +2,26 @@ syntax = "proto3";
 
 package typedb.protocol;
 
-message PeeringRequest {
-  uint64 from_id = 1;
-  string from_address = 2;
-  bytes message = 3;
+import "proto/server.proto";
+
+message Peering {
+    message Req {
+        uint64 from_id = 1;
+        string from_address = 2;
+        bytes message = 3;
+    }
+
+    message Res {}
 }
 
-message PeeringResponse {
+message ServerStatus {
+    message Req {}
+
+    message Res {
+        // TODO: Currently, it's identical to Server. But it won't necessarily be the case forever, so these fields are
+        // split. Additionally, we want to highlight that the address is the connection address.
+        // TODO: We may move ReplicaStatus somewhere else now...
+        string connection_address = 1;
+        Server.ReplicaStatus replica_status = 2;
+    }
 }

--- a/proto/raft-peering.proto
+++ b/proto/raft-peering.proto
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 syntax = "proto3";
 
 package typedb.protocol;

--- a/proto/server.proto
+++ b/proto/server.proto
@@ -41,7 +41,8 @@ message Server {
 
         enum ReplicaType {
             Primary = 0;
-            Secondary = 1;
+            Candidate = 1;
+            Secondary = 2;
         }
     }
 


### PR DESCRIPTION
## Release notes: usage and product changes
Add server_status message to the raft peering service and rename the old raft peering messages to adjust to the existing naming conventions.

## Implementation

